### PR TITLE
Make pyvcell.vcml imports lazy (PEP 562)

### DIFF
--- a/pyvcell/vcml/__init__.py
+++ b/pyvcell/vcml/__init__.py
@@ -1,81 +1,199 @@
-from pyvcell._internal.geometry import SegmentedImageGeometry
-from pyvcell.vcml.field import Field
-from pyvcell.vcml.models import (
-    Application,
-    Biomodel,
-    BoundaryType,
-    Compartment,
-    Kinetics,
-    KineticsParameter,
-    Model,
-    ModelParameter,
-    Reaction,
-    Simulation,
-    Species,
-    SpeciesMapping,
-    SpeciesReference,
-    SpeciesRefType,
-    VCMLDocument,
-    Version,
-)
-from pyvcell.vcml.models_geometry import (
-    Geometry,
-    Image,
-    PixelClass,
-    SubVolume,
-    SubVolumeType,
-    SurfaceClass,
-)
-from pyvcell.vcml.models_math import (
-    Boundaries,
-    CompartmentSubDomain,
-    Constant,
-    Effect,
-    JumpCondition,
-    JumpProcess,
-    MathBoundaryType,
-    MathDescription,
-    MathFunction,
-    MathVariable,
-    MathVariableType,
-    MembraneSubDomain,
-    OdeEquation,
-    ParticleInitialCount,
-    ParticleJumpProcess,
-    ParticleProperties,
-    PdeEquation,
-    VariableInitialCount,
-    Velocity,
-)
-from pyvcell.vcml.session import SimulationJob, VCellSession
-from pyvcell.vcml.utils import (
-    field_data_refs,
-    load_antimony_file,
-    load_antimony_str,
-    load_sbml_file,
-    load_sbml_str,
-    load_sbml_url,
-    load_vcml_file,
-    load_vcml_str,
-    load_vcml_url,
-    restore_stdout,
-    suppress_stdout,
-    to_antimony_str,
-    to_sbml_str,
-    to_vcml_str,
-    update_biomodel,
-    write_antimony_file,
-    write_sbml_file,
-    write_vcml_file,
-)
-from pyvcell.vcml.vcml_reader import VcmlReader
-from pyvcell.vcml.vcml_remote import connect, logout
-from pyvcell.vcml.vcml_simulation import simulate
-from pyvcell.vcml.vcml_writer import VcmlWriter
-from pyvcell.vcml.workspace import get_workspace_dir, set_workspace_dir
+"""Public API for ``pyvcell.vcml``.
+
+Imports are lazy (PEP 562). Importing this package does **not** eagerly pull in
+the heavy submodules (``session`` / ``vcml_remote`` / ``vcml_simulation`` /
+``utils`` and their libvcell, requests, generated-REST-client, sympy and zarr
+dependencies). Each public name is loaded from its defining submodule only on
+first access, so importing just the datamodels — e.g. ``import
+pyvcell.vcml.models_math`` or ``from pyvcell.vcml import MathDescription`` — stays
+lightweight (only pydantic, plus numpy for the geometry model).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Eagerly visible to type checkers / IDEs; never executed at runtime.
+    from pyvcell._internal.geometry import SegmentedImageGeometry
+    from pyvcell.vcml.field import Field
+    from pyvcell.vcml.models import (
+        Application,
+        Biomodel,
+        BoundaryType,
+        Compartment,
+        Kinetics,
+        KineticsParameter,
+        Model,
+        ModelParameter,
+        Reaction,
+        Simulation,
+        Species,
+        SpeciesMapping,
+        SpeciesReference,
+        SpeciesRefType,
+        VCMLDocument,
+        Version,
+    )
+    from pyvcell.vcml.models_geometry import (
+        Geometry,
+        Image,
+        PixelClass,
+        SubVolume,
+        SubVolumeType,
+        SurfaceClass,
+    )
+    from pyvcell.vcml.models_math import (
+        Boundaries,
+        CompartmentSubDomain,
+        Constant,
+        Effect,
+        JumpCondition,
+        JumpProcess,
+        MathBoundaryType,
+        MathDescription,
+        MathFunction,
+        MathVariable,
+        MathVariableType,
+        MembraneSubDomain,
+        OdeEquation,
+        ParticleInitialCount,
+        ParticleJumpProcess,
+        ParticleProperties,
+        PdeEquation,
+        VariableInitialCount,
+        Velocity,
+    )
+    from pyvcell.vcml.session import SimulationJob, VCellSession
+    from pyvcell.vcml.utils import (
+        field_data_refs,
+        load_antimony_file,
+        load_antimony_str,
+        load_sbml_file,
+        load_sbml_str,
+        load_sbml_url,
+        load_vcml_file,
+        load_vcml_str,
+        load_vcml_url,
+        restore_stdout,
+        suppress_stdout,
+        to_antimony_str,
+        to_sbml_str,
+        to_vcml_str,
+        update_biomodel,
+        write_antimony_file,
+        write_sbml_file,
+        write_vcml_file,
+    )
+    from pyvcell.vcml.vcml_reader import VcmlReader
+    from pyvcell.vcml.vcml_remote import connect, logout
+    from pyvcell.vcml.vcml_simulation import simulate
+    from pyvcell.vcml.vcml_writer import VcmlWriter
+    from pyvcell.vcml.workspace import get_workspace_dir, set_workspace_dir
+
+
+# Each public name -> the submodule that defines (or re-exports) it. The submodule
+# is imported lazily on first attribute access; lightweight datamodel submodules
+# (models, models_geometry, models_math) never trigger the heavy ones.
+_LAZY_IMPORTS: dict[str, str] = {
+    "SegmentedImageGeometry": "pyvcell._internal.geometry",
+    "Field": "pyvcell.vcml.field",
+    **dict.fromkeys(
+        [
+            "Application",
+            "Biomodel",
+            "BoundaryType",
+            "Compartment",
+            "Kinetics",
+            "KineticsParameter",
+            "Model",
+            "ModelParameter",
+            "Reaction",
+            "Simulation",
+            "Species",
+            "SpeciesMapping",
+            "SpeciesReference",
+            "SpeciesRefType",
+            "VCMLDocument",
+            "Version",
+        ],
+        "pyvcell.vcml.models",
+    ),
+    **dict.fromkeys(
+        ["Geometry", "Image", "PixelClass", "SubVolume", "SubVolumeType", "SurfaceClass"],
+        "pyvcell.vcml.models_geometry",
+    ),
+    **dict.fromkeys(
+        [
+            "Boundaries",
+            "CompartmentSubDomain",
+            "Constant",
+            "Effect",
+            "JumpCondition",
+            "JumpProcess",
+            "MathBoundaryType",
+            "MathDescription",
+            "MathFunction",
+            "MathVariable",
+            "MathVariableType",
+            "MembraneSubDomain",
+            "OdeEquation",
+            "ParticleInitialCount",
+            "ParticleJumpProcess",
+            "ParticleProperties",
+            "PdeEquation",
+            "VariableInitialCount",
+            "Velocity",
+        ],
+        "pyvcell.vcml.models_math",
+    ),
+    **dict.fromkeys(["SimulationJob", "VCellSession"], "pyvcell.vcml.session"),
+    **dict.fromkeys(
+        [
+            "field_data_refs",
+            "load_antimony_file",
+            "load_antimony_str",
+            "load_sbml_file",
+            "load_sbml_str",
+            "load_sbml_url",
+            "load_vcml_file",
+            "load_vcml_str",
+            "load_vcml_url",
+            "restore_stdout",
+            "suppress_stdout",
+            "to_antimony_str",
+            "to_sbml_str",
+            "to_vcml_str",
+            "update_biomodel",
+            "write_antimony_file",
+            "write_sbml_file",
+            "write_vcml_file",
+        ],
+        "pyvcell.vcml.utils",
+    ),
+    "VcmlReader": "pyvcell.vcml.vcml_reader",
+    **dict.fromkeys(["connect", "logout"], "pyvcell.vcml.vcml_remote"),
+    "simulate": "pyvcell.vcml.vcml_simulation",
+    "VcmlWriter": "pyvcell.vcml.vcml_writer",
+    **dict.fromkeys(["get_workspace_dir", "set_workspace_dir"], "pyvcell.vcml.workspace"),
+}
+
+
+def __getattr__(name: str) -> object:
+    module_path = _LAZY_IMPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value  # cache so __getattr__ is not consulted again for this name
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
-    "Application",
     "Application",
     "Biomodel",
     "Boundaries",


### PR DESCRIPTION
## Problem

Following the datamodel module split (`models_base` / `models_geometry` / `models_math` / `models_app` / `models`), a third party that wants only the geometry/math datamodels still paid for the entire stack. Importing any submodule first executes `pyvcell/vcml/__init__.py`, which eagerly imported `session` / `vcml_remote` / `vcml_simulation` / `utils` — transitively loading **libvcell, requests, the generated REST client, sympy, zarr, pyvista, matplotlib**.

Measured before:

```
import pyvcell.vcml.models_math  ->  ~4.72s, 1647 modules
  heavy deps: libvcell, sympy, zarr, pyvista, matplotlib, lxml, pydantic
  generated REST client modules: 105
```

## Fix

Convert `pyvcell/vcml/__init__.py` to **PEP 562 lazy loading**: a module-level `__getattr__` maps each public name to the submodule that defines (or re-exports) it and imports that submodule only on first access. A `TYPE_CHECKING` block keeps the eager imports visible to type checkers / IDEs, so static types and autocomplete are unchanged.

Measured after:

| import | time | modules | heavy deps |
|---|---|---|---|
| `pyvcell.vcml.models_math` | **0.10s** | **263** | none |
| `pyvcell.vcml.models_geometry` | — | 367 | numpy + numexpr only |
| `pyvcell.vcml.models_base` | — | minimal | pydantic only |

A geometry-/math-only consumer now pulls in just pydantic (plus numpy for the geometry model) — no libvcell, requests, REST client, sympy, or zarr.

## Compatibility

The public API is unchanged. `import pyvcell.vcml as vc` followed by `vc.connect(...)`, `vc.VcmlReader`, `vc.MathDescription`, `vc.to_vcml_str(...)`, and `from pyvcell.vcml import Biomodel, get_workspace_dir` all still resolve (the heavy bits just load on first use). Submodule imports (`import pyvcell.vcml.models`) are unaffected.

## Verification

- `make check` passes — mypy clean across 307 files (the `TYPE_CHECKING` block preserves precise types through `__getattr__`), pre-commit and deptry clean.
- Tests green, including those that use package-level `from pyvcell.vcml import ...` (`test_creation`, `test_utils`, `test_fielddata`, `test_math_description`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)