### PR TITLE
Run plotting tests headless (no blocking GUI windows)

### DIFF
--- a/tests/_headless.py
+++ b/tests/_headless.py
@@ -14,6 +14,6 @@ os.environ.setdefault("PYVISTA_OFF_SCREEN", "true")
 # matplotlib reads this at import time to select a non-interactive backend.
 os.environ.setdefault("MPLBACKEND", "Agg")
 
-import matplotlib  # noqa: E402
+import matplotlib
 
 matplotlib.use("Agg", force=True)

--- a/tests/_headless.py
+++ b/tests/_headless.py
@@ -1,0 +1,19 @@
+"""Force headless rendering for the test suite.
+
+Imported first from ``conftest.py`` so that matplotlib and pyvista never open
+interactive GUI windows that would block the run (requiring the user to close
+them by hand). Setting the environment variables before those libraries are
+first imported makes the choice stick; ``matplotlib.use(..., force=True)`` also
+switches the backend in case matplotlib was already imported.
+"""
+
+import os
+
+# pyvista reads this at import time to default Plotter(off_screen=...) to True.
+os.environ.setdefault("PYVISTA_OFF_SCREEN", "true")
+# matplotlib reads this at import time to select a non-interactive backend.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg", force=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import tests._headless  # noqa: F401  # isort:skip  must be first: configures headless rendering
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Problem

Several tests render plots — `result.plotter.plot_concentrations()` / `plot_slice_2d` / `plot_slice_3d` (matplotlib `plt.show()`), plus geometry/VTK plotting. On a machine with an interactive matplotlib backend (e.g. macOS), these pop up GUI windows that **block the test run until the user closes each one by hand**.

The `Agg` backend was only set ad-hoc in two files (`tests/sim_results/test_result.py`, `test_model_with_logic_in_expressions.py`). Notably `tests/vcml/test_creation.py` calls `plot_concentrations()` and ten `plot_slice_*` methods with no such guard.

## Fix

Add `tests/_headless.py`, imported first from `conftest.py`, which — before matplotlib / pyvista are first imported anywhere in the session:

- sets `MPLBACKEND=Agg` (non-interactive matplotlib backend → `plt.show()` is a no-op)
- sets `PYVISTA_OFF_SCREEN=true` (pyvista `Plotter` defaults to off-screen)
- calls `matplotlib.use("Agg", force=True)` as a belt-and-suspenders override

The suite now runs unattended/offline with no windows to close. The existing per-file `matplotlib.use("Agg")` lines are kept (they still help if a test file is run directly without `conftest`).

## Verification

- Headless mechanism confirmed: in a fresh process, `import tests._headless` yields `MPLBACKEND=Agg`, `PYVISTA_OFF_SCREEN=true`, `matplotlib.get_backend() == 'Agg'`.
- The previously window-popping tests pass headlessly: `tests/vcml/test_creation.py`, `tests/sim_results/test_result.py`, `tests/sim_results/test_model_with_logic_in_expressions.py`, `tests/_internal/geometry/test_segmented_image_geometry.py` — 15 passed in 4.6s.
- `make check` passes (pre-commit, mypy, deptry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)