### PR TITLE
Lenient VCML reader: parse best-effort, preserve MathDescription + Geometry

### DIFF
--- a/pyvcell/vcml/vcml_reader.py
+++ b/pyvcell/vcml/vcml_reader.py
@@ -1,3 +1,4 @@
+import logging
 from os import PathLike
 
 from lxml import etree
@@ -6,6 +7,8 @@ from lxml.etree import _Element
 import pyvcell.vcml.models as vc
 import pyvcell.vcml.models_geometry as vcg
 import pyvcell.vcml.models_math as vcm
+
+logger = logging.getLogger(__name__)
 
 
 def float_or_formula(text: str) -> str | float:
@@ -72,7 +75,13 @@ class XMLVisitor:
 
     def generic_visit(self, element: _Element, node: vc.VcmlNode) -> None:
         for child in element:
-            self.visit(child, node)
+            # Best-effort parse: an unmodeled or malformed physiology subtree should
+            # cost us that subtree, not abort the whole document (and in particular not
+            # the SimulationSpec's MathDescription/Geometry, which parse independently).
+            try:
+                self.visit(child, node)
+            except Exception:
+                logger.debug("skipping unparsable <%s> element", strip_namespace(child.tag), exc_info=True)
 
 
 class BiomodelVisitor(XMLVisitor):
@@ -143,7 +152,11 @@ class BiomodelVisitor(XMLVisitor):
         node.products.append(reaction)
         self.generic_visit(element, reaction)
 
-    def visit_Kinetics(self, element: _Element, node: vc.Reaction) -> None:
+    def visit_Kinetics(self, element: _Element, node: vc.VcmlNode) -> None:
+        # Only attach kinetics to an actual reaction. A <Kinetics> reached with a
+        # non-Reaction node (its reaction-container isn't modeled) is skipped.
+        if not isinstance(node, vc.Reaction):
+            return
         kinetics_type: str = element.get("KineticsType", default="GeneralKinetics")
         kinetics = vc.Kinetics(kinetics_type=kinetics_type)
         node.kinetics = kinetics
@@ -165,39 +178,37 @@ class BiomodelVisitor(XMLVisitor):
         species = vc.Species(name=name, compartment_name=structure)
         node.species.append(species)
 
-    def visit_Parameter(self, element: _Element, node: vc.Model | vc.Kinetics) -> None:
+    def visit_Parameter(self, element: _Element, node: vc.VcmlNode) -> None:
         parent: _Element | None = element.getparent()
         if parent is None:
-            raise ValueError("Parameter element has no parent")
+            return
+        parent_tag = strip_namespace(parent.tag)
         text: str = element.text or ""
         value: str | float = float_or_formula(text)
         name: str = element.get("Name", default="unnamed")
         role = element.get("Role", default="user defined")
         unit = element.get("Unit", default="tbd")
         parameter: vc.ModelParameter | vc.KineticsParameter | vc.ApplicationParameter
-        if strip_namespace(parent.tag) == "ModelParameters":
-            model: vc.Model = node  # type: ignore[assignment]
+        if parent_tag == "ModelParameters" and isinstance(node, vc.Model):
             model_parameter = vc.ModelParameter(name=name, value=value, role=role, unit=unit)
-            model.model_parameters.append(model_parameter)
+            node.model_parameters.append(model_parameter)
             parameter = model_parameter
-        elif strip_namespace(parent.tag) == "Kinetics":
-            kinetics: vc.Kinetics = node  # type: ignore[assignment]
+        elif parent_tag == "Kinetics" and isinstance(node, vc.Kinetics):
             reaction_node = parent.getparent()
-            if reaction_node is None:
-                raise ValueError("Kinetics element has no parent")
-            reaction_name = reaction_node.get("Name", default="unknown")
+            reaction_name = reaction_node.get("Name", default="unknown") if reaction_node is not None else "unknown"
             kinetics_parameter = vc.KineticsParameter(
                 name=name, value=value, role=role, unit=unit, reaction_name=reaction_name
             )
-            kinetics.kinetics_parameters.append(kinetics_parameter)
+            node.kinetics_parameters.append(kinetics_parameter)
             parameter = kinetics_parameter
-        elif strip_namespace(parent.tag) == "ApplicationParameters":
-            application: vc.Application = node  # type: ignore[assignment]
+        elif parent_tag == "ApplicationParameters" and isinstance(node, vc.Application):
             application_parameter = vc.ApplicationParameter(name=name, value=value, role=role, unit=unit)
-            application.application_parameters.append(application_parameter)
+            node.application_parameters.append(application_parameter)
             parameter = application_parameter
         else:
-            raise ValueError("Unexpected parent tag")
+            # A <Parameter> in a context the data model doesn't represent (rate rules,
+            # structure/species-context mappings, electrical params, …) — skip it.
+            return
         self.generic_visit(element, parameter)
 
     def visit_SimulationSpec(self, element: _Element, node: vc.Biomodel) -> None:
@@ -231,8 +242,8 @@ class BiomodelVisitor(XMLVisitor):
                         mesh_size = (mesh_x, mesh_y, mesh_z)
         if mesh_size is None:
             return  # nonspatial simulation
-        if duration is None or output_time_step is None or mesh_size is None:
-            raise ValueError("Simulation element is missing required child elements")
+        if duration is None or output_time_step is None:
+            return  # incomplete simulation spec — skip this Simulation, keep the rest
         simulation = vc.Simulation(
             name=name,
             duration=duration,

--- a/tests/vcml/test_reader_leniency.py
+++ b/tests/vcml/test_reader_leniency.py
@@ -1,0 +1,107 @@
+"""The reader should parse best-effort: unmodeled / malformed physiology elements
+are skipped instead of aborting the whole biomodel, so a SimulationSpec's
+MathDescription and Geometry still load.
+
+These minimal documents reproduce the three constructs that previously aborted
+~23% of real public biomodels:
+  - a stray ``<Parameter>`` outside the modeled containers ("Unexpected parent tag")
+  - a ``<Kinetics>`` reached with a non-Reaction node ('"Model" object has no field "kinetics"')
+  - a ``<Simulation>`` missing its solver/timebound children ("missing required child elements")
+"""
+
+import pyvcell.vcml as vc
+
+# A BioModel whose physiology contains all three previously-fatal constructs,
+# alongside a SimulationSpec that carries a real Geometry and MathDescription.
+LENIENT_VCML = """<?xml version="1.0" encoding="UTF-8"?>
+<vcml xmlns="http://sourceforge.net/projects/vcell/vcml" Version="test">
+  <BioModel Name="LenientTest">
+    <Model Name="m">
+      <ModelParameters>
+        <Parameter Name="k" Role="user defined" Unit="s-1">1.0</Parameter>
+      </ModelParameters>
+      <Feature Name="cell"/>
+      <UnmodeledReactionContainer>
+        <Kinetics KineticsType="GeneralKinetics">
+          <Parameter Name="kStray" Role="user defined" Unit="x">2.0</Parameter>
+        </Kinetics>
+      </UnmodeledReactionContainer>
+      <RateRule>
+        <Parameter Name="pStray" Role="user defined" Unit="u">3.0</Parameter>
+      </RateRule>
+    </Model>
+    <SimulationSpec Name="app" Stochastic="false">
+      <Geometry Name="geo" Dimension="3">
+        <Extent X="1.0" Y="1.0" Z="1.0"/>
+        <Origin X="0.0" Y="0.0" Z="0.0"/>
+        <SubVolume Name="subdomain0" Handle="0" Type="Analytical">
+          <AnalyticExpression>1.0</AnalyticExpression>
+        </SubVolume>
+      </Geometry>
+      <MathDescription Name="app_generated">
+        <Constant Name="kConst">1.0</Constant>
+        <VolumeVariable Name="u" Domain="subdomain0"/>
+        <CompartmentSubDomain Name="subdomain0">
+          <BoundaryType Boundary="Xm" Type="Value"/>
+          <OdeEquation Name="u">
+            <Rate>0.0</Rate>
+            <Initial>kConst</Initial>
+          </OdeEquation>
+        </CompartmentSubDomain>
+      </MathDescription>
+      <Simulation Name="incomplete">
+        <MeshSpecification>
+          <Size X="10" Y="10" Z="10"/>
+        </MeshSpecification>
+      </Simulation>
+    </SimulationSpec>
+  </BioModel>
+</vcml>
+"""
+
+
+def test_lenient_parse_preserves_math_and_geometry() -> None:
+    biomodel = vc.VcmlReader.biomodel_from_str(LENIENT_VCML)
+
+    # The document loads despite the stray Parameter / Kinetics and childless Simulation.
+    assert biomodel is not None
+    assert biomodel.name == "LenientTest"
+
+    # Faithful physiology that IS modeled is still parsed.
+    assert biomodel.model is not None
+    assert [c.name for c in biomodel.model.compartments] == ["cell"]
+    assert [p.name for p in biomodel.model.model_parameters] == ["k"]
+
+    app = biomodel.applications[0]
+
+    # Geometry survives intact.
+    assert app.geometry.name == "geo"
+    assert app.geometry.subvolume_names == ["subdomain0"]
+
+    # MathDescription survives intact.
+    assert app.math_description is not None
+    assert [const.name for const in app.math_description.constants] == ["kConst"]
+    subdomain = app.math_description.compartment_subdomains[0]
+    assert [ode.name for ode in subdomain.ode_equations] == ["u"]
+
+    # The incomplete Simulation is skipped (not fatal), the rest is preserved.
+    assert app.simulations == []
+
+
+def test_stray_kinetics_does_not_abort() -> None:
+    """A <Kinetics> under a non-reaction container is skipped, not fatal."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<vcml xmlns="http://sourceforge.net/projects/vcell/vcml" Version="test">
+  <BioModel Name="StrayKinetics">
+    <Model Name="m">
+      <Feature Name="cell"/>
+      <SomeContainer>
+        <Kinetics KineticsType="GeneralKinetics"/>
+      </SomeContainer>
+    </Model>
+  </BioModel>
+</vcml>
+"""
+    biomodel = vc.VcmlReader.biomodel_from_str(xml)
+    assert biomodel.model is not None
+    assert [c.name for c in biomodel.model.compartments] == ["cell"]


### PR DESCRIPTION
## Problem

`VcmlReader` aborted the **entire** biomodel load whenever a physiology visitor raised on a construct the data model doesn't cover — discarding the `SimulationSpec`'s `MathDescription` and `Geometry`, which parse fine on their own. On a corpus of 2766 real public biomodels (`../vcell-fenics/vcml_biomodels`) this failed ~23%:

```
loaded 2137/2766 (77%)
  354  Unexpected parent tag
  150  "Model" object has no field "kinetics"
  125  Simulation element is missing required child elements
```

## Root cause

`XMLVisitor.visit` dispatches `visit_<Tag>` with a `generic_visit` fallback that recurses into all children carrying whatever parent `node` it has. So a `<Kinetics>` / `<Parameter>` under an unmodeled container gets dispatched with the wrong node type, and the visitor raises — aborting the whole document.

## Changes (`pyvcell/vcml/vcml_reader.py`)

Make the physiology visitors best-effort; an unmodeled construct is skipped, never fatal. The data model is unchanged (no bogus fields added).

- **`visit_Kinetics`** — only attach kinetics when the node is actually a `Reaction` (`isinstance` guard); otherwise skip.
- **`visit_Parameter`** — guard each branch by node type; skip a `<Parameter>` in a context the model doesn't represent (rate rules, structure/species-context mappings, electrical params, …) instead of `raise ValueError("Unexpected parent tag")`.
- **`visit_Simulation`** — skip an incomplete `Simulation` (missing solver/timebound children) instead of raising.
- **`generic_visit`** — per-child backstop that catches, logs at `debug`, and skips an unparsable subtree, so a malformed/unmodeled subtree costs that subtree, not the document (and not the MathDescription/Geometry).

## Results

| | before | after |
|---|---|---|
| corpus load | 2137/2766 (77%) | **2766/2766 (100%)** |
| the three errors | 354 / 150 / 125 | **0 / 0 / 0** |

All **629** previously-failing files now load; **627** of them with their `MathDescription` and `Geometry` populated (the other 2 are genuinely math/geometry-less models). Example previously-failing models now parse with full math + geometry, e.g. `biomodel_100059482.vcml` → app "3D pde" with 28 constants, 3 subdomains, 3 subvolumes.

## No regression

The data model is untouched. Existing `tests/vcml/test_vcml_reader.py` / `test_vcml_writer.py` / `test_math_description.py` still pass with identical structure (they assert exact math/geometry/model contents). New `tests/vcml/test_reader_leniency.py` reproduces all three constructs in self-contained minimal VCML (no external-corpus dependency) and asserts the biomodel loads with its application's math + geometry intact.

`make check` passes (ruff, mypy across 308 files, deptry); `pytest tests/vcml` → 37 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)