### PR TITLE
Lightweight data/VCML layer: lazy heavy deps + optional-dependency extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,39 +14,62 @@ authors = [
 packages = [
     {include="pyvcell"},
 ]
+# Core: just what the data models + VCML reader/writer need. Heavy runtime deps
+# live in the optional-dependencies extras below; install pyvcell[all] for the
+# full feature set (solver, viz, remote, io, convert, native).
 dependencies = [
-    "antimony (>=3.1.3)",
-    "h5py>=3.11.0,<4",
-    "imageio>=2.37.0,<3",
-    "libvcell (>=0.0.15.2)",
     "lxml>=6.1.0,<7",
-    "matplotlib>=3.10.0,<4",
     "numexpr>=2.10,<3",
     "numpy>=1.26.4,<3.0",
-    "orjson>=3.10.3,<4",
-    "overrides>=7.7.0,<8",
     "pydantic>=2.10.5,<3",
-    "python-dateutil>=2.8.2,<3",
-    "python-libsbml>=5.20.4,<6",
+    "typing-extensions>=4.12.2,<5",
+]
+
+[project.optional-dependencies]
+solver = [
     "pyvcell-fvsolver (>=0.2.1)",
+]
+viz = [
+    "imageio>=2.37.0,<3",
+    "matplotlib>=3.10.0,<4",
     "pyvista>=0.44.2,<1",
-    "requests>=2.32.3,<3",
-    "requests-oauth2client>=1.6.0,<2",
-    "sympy>=1.13.1,<2",
-    "tensorstore>=0.1.72,<1",
     "trame>=3.8.1,<4",
     "trame-server>=3.4.0,<4",
     "trame-vtk>=2.8.15,<3",
     "trame-vuetify>=3.2.2,<4",
-    "typer>=0.12.3,<1.0.0",
-    "typing-extensions>=4.12.2,<5",
-    "urllib3>=2.3.0,<3",
     "vtk>=9.3.1,<10",
+]
+remote = [
+    "overrides>=7.7.0,<8",
+    "python-dateutil>=2.8.2,<3",
+    "requests>=2.32.3,<3",
+    "requests-oauth2client>=1.6.0,<2",
+    "urllib3>=2.3.0,<3",
+]
+io = [
+    "h5py>=3.11.0,<4",
+    "orjson>=3.10.3,<4",
+    "tensorstore>=0.1.72,<1",
+    "typer>=0.12.3,<1.0.0",
     "zarr>=2.17.2,<3", # major upgrade will take some work!
+]
+convert = [
+    "antimony (>=3.1.3)",
+    "python-libsbml>=5.20.4,<6",
+    "sympy>=1.13.1,<2",
+]
+native = [
+    "libvcell (>=0.0.15.2)",
+]
+all = [
+    "pyvcell[solver,viz,remote,io,convert,native]",
 ]
 
 [dependency-groups]
 dev = [
+    # Dev/CI work against the full feature set (all optional extras). End users
+    # opt in per extra (e.g. `pip install pyvcell[viz]`) or `pip install pyvcell[all]`.
+    "pyvcell[all]",
     "pytest>=7.2.0,<8",
     "pytest-cov>=4.0.0,<5",
     "deptry>=0.16.2,<1",
@@ -75,6 +98,12 @@ build-backend = "uv_build"
 [tool.uv.build-backend]
 module-name = "pyvcell"
 module-root = ""
+
+[tool.deptry.per_rule_ignores]
+# `pyvcell[all]` is in the dev group so dev/CI install every optional extra;
+# it is a self-reference (first-party), so deptry's "unused dependency" check
+# does not apply.
+DEP002 = ["pyvcell"]
 
 [tool.mypy]
 files = ["pyvcell", "tests", "examples"]

--- a/pyvcell/_internal/simdata/python_infix.py
+++ b/pyvcell/_internal/simdata/python_infix.py
@@ -1,7 +1,8 @@
-from libvcell import vcell_infix_to_num_expr_infix
-
-
 def get_numexpr_expression(vcell_expression: str) -> str:
+    # libvcell (the `native` extra) is imported lazily so that importing the data
+    # models / VCML reader does not require it.
+    from libvcell import vcell_infix_to_num_expr_infix
+
     # First, get the string from vcell
     translation_result: bool
     result_message: str

--- a/pyvcell/sbml/sbml_simulation.py
+++ b/pyvcell/sbml/sbml_simulation.py
@@ -3,8 +3,6 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from libvcell import sbml_to_finite_volume_input
-
 from pyvcell._internal.solvers.fvsolver import solve as fvsolve
 from pyvcell.sbml.sbml_spatial_model import SbmlSpatialModel
 from pyvcell.sim_results.result import Result
@@ -22,6 +20,8 @@ class SbmlSpatialSimulation:
             self.out_dir = out_dir if isinstance(out_dir, Path) else Path(out_dir)
 
     def run(self, duration: float | None = None, output_time_step: float | None = None) -> Result:
+        from libvcell import sbml_to_finite_volume_input
+
         # prepare solver input files
         # 1. upload the SBML model and retrieve generated solver inputs as a zip file
         # 2. extract the zip archive into the output directory

--- a/pyvcell/vcml/__init__.py
+++ b/pyvcell/vcml/__init__.py
@@ -1,12 +1,13 @@
 """Public API for ``pyvcell.vcml``.
 
-Imports are lazy (PEP 562). Importing this package does **not** eagerly pull in
-the heavy submodules (``session`` / ``vcml_remote`` / ``vcml_simulation`` /
-``utils`` and their libvcell, requests, generated-REST-client, sympy and zarr
-dependencies). Each public name is loaded from its defining submodule only on
-first access, so importing just the datamodels — e.g. ``import
-pyvcell.vcml.models_math`` or ``from pyvcell.vcml import MathDescription`` — stays
-lightweight (only pydantic, plus numpy for the geometry model).
+The lightweight data layer is eager: the data models (``models``,
+``models_geometry``, ``models_math``) and ``VcmlReader`` import with only the
+core dependencies (pydantic, lxml, numpy, numexpr). Everything that needs a
+heavy optional dependency — ``VcmlWriter``, ``Field``, ``SegmentedImageGeometry``,
+the remote ``VCellSession`` / ``connect`` / ``simulate`` API, and the ``utils`` /
+``workspace`` helpers — is imported lazily (PEP 562) on first access. If the
+optional dependency is missing, the lazy import raises a clear error naming the
+extra to install (e.g. ``pip install pyvcell[viz]``).
 """
 
 from __future__ import annotations
@@ -14,57 +15,60 @@ from __future__ import annotations
 import importlib
 from typing import TYPE_CHECKING
 
+# --- eager, lightweight: data models + VCML reader (core deps only) ---
+from pyvcell.vcml.models import (
+    Application,
+    Biomodel,
+    BoundaryType,
+    Compartment,
+    Kinetics,
+    KineticsParameter,
+    Model,
+    ModelParameter,
+    Reaction,
+    Simulation,
+    Species,
+    SpeciesMapping,
+    SpeciesReference,
+    SpeciesRefType,
+    VCMLDocument,
+    Version,
+)
+from pyvcell.vcml.models_geometry import (
+    Geometry,
+    Image,
+    PixelClass,
+    SubVolume,
+    SubVolumeType,
+    SurfaceClass,
+)
+from pyvcell.vcml.models_math import (
+    Boundaries,
+    CompartmentSubDomain,
+    Constant,
+    Effect,
+    JumpCondition,
+    JumpProcess,
+    MathBoundaryType,
+    MathDescription,
+    MathFunction,
+    MathVariable,
+    MathVariableType,
+    MembraneSubDomain,
+    OdeEquation,
+    ParticleInitialCount,
+    ParticleJumpProcess,
+    ParticleProperties,
+    PdeEquation,
+    VariableInitialCount,
+    Velocity,
+)
+from pyvcell.vcml.vcml_reader import VcmlReader
+
 if TYPE_CHECKING:
-    # Eagerly visible to type checkers / IDEs; never executed at runtime.
+    # Heavy names — eager only for type checkers / IDE autocomplete.
     from pyvcell._internal.geometry import SegmentedImageGeometry
     from pyvcell.vcml.field import Field
-    from pyvcell.vcml.models import (
-        Application,
-        Biomodel,
-        BoundaryType,
-        Compartment,
-        Kinetics,
-        KineticsParameter,
-        Model,
-        ModelParameter,
-        Reaction,
-        Simulation,
-        Species,
-        SpeciesMapping,
-        SpeciesReference,
-        SpeciesRefType,
-        VCMLDocument,
-        Version,
-    )
-    from pyvcell.vcml.models_geometry import (
-        Geometry,
-        Image,
-        PixelClass,
-        SubVolume,
-        SubVolumeType,
-        SurfaceClass,
-    )
-    from pyvcell.vcml.models_math import (
-        Boundaries,
-        CompartmentSubDomain,
-        Constant,
-        Effect,
-        JumpCondition,
-        JumpProcess,
-        MathBoundaryType,
-        MathDescription,
-        MathFunction,
-        MathVariable,
-        MathVariableType,
-        MembraneSubDomain,
-        OdeEquation,
-        ParticleInitialCount,
-        ParticleJumpProcess,
-        ParticleProperties,
-        PdeEquation,
-        VariableInitialCount,
-        Velocity,
-    )
     from pyvcell.vcml.session import SimulationJob, VCellSession
     from pyvcell.vcml.utils import (
         field_data_refs,
@@ -86,69 +90,21 @@ if TYPE_CHECKING:
         write_sbml_file,
         write_vcml_file,
     )
-    from pyvcell.vcml.vcml_reader import VcmlReader
     from pyvcell.vcml.vcml_remote import connect, logout
     from pyvcell.vcml.vcml_simulation import simulate
     from pyvcell.vcml.vcml_writer import VcmlWriter
     from pyvcell.vcml.workspace import get_workspace_dir, set_workspace_dir
 
 
-# Each public name -> the submodule that defines (or re-exports) it. The submodule
-# is imported lazily on first attribute access; lightweight datamodel submodules
-# (models, models_geometry, models_math) never trigger the heavy ones.
+# Heavy public name -> the submodule that defines it (imported on first access).
 _LAZY_IMPORTS: dict[str, str] = {
     "SegmentedImageGeometry": "pyvcell._internal.geometry",
     "Field": "pyvcell.vcml.field",
-    **dict.fromkeys(
-        [
-            "Application",
-            "Biomodel",
-            "BoundaryType",
-            "Compartment",
-            "Kinetics",
-            "KineticsParameter",
-            "Model",
-            "ModelParameter",
-            "Reaction",
-            "Simulation",
-            "Species",
-            "SpeciesMapping",
-            "SpeciesReference",
-            "SpeciesRefType",
-            "VCMLDocument",
-            "Version",
-        ],
-        "pyvcell.vcml.models",
-    ),
-    **dict.fromkeys(
-        ["Geometry", "Image", "PixelClass", "SubVolume", "SubVolumeType", "SurfaceClass"],
-        "pyvcell.vcml.models_geometry",
-    ),
-    **dict.fromkeys(
-        [
-            "Boundaries",
-            "CompartmentSubDomain",
-            "Constant",
-            "Effect",
-            "JumpCondition",
-            "JumpProcess",
-            "MathBoundaryType",
-            "MathDescription",
-            "MathFunction",
-            "MathVariable",
-            "MathVariableType",
-            "MembraneSubDomain",
-            "OdeEquation",
-            "ParticleInitialCount",
-            "ParticleJumpProcess",
-            "ParticleProperties",
-            "PdeEquation",
-            "VariableInitialCount",
-            "Velocity",
-        ],
-        "pyvcell.vcml.models_math",
-    ),
+    "VcmlWriter": "pyvcell.vcml.vcml_writer",
     **dict.fromkeys(["SimulationJob", "VCellSession"], "pyvcell.vcml.session"),
+    **dict.fromkeys(["connect", "logout"], "pyvcell.vcml.vcml_remote"),
+    "simulate": "pyvcell.vcml.vcml_simulation",
+    **dict.fromkeys(["get_workspace_dir", "set_workspace_dir"], "pyvcell.vcml.workspace"),
     **dict.fromkeys(
         [
             "field_data_refs",
@@ -172,11 +128,34 @@ _LAZY_IMPORTS: dict[str, str] = {
         ],
         "pyvcell.vcml.utils",
     ),
-    "VcmlReader": "pyvcell.vcml.vcml_reader",
-    **dict.fromkeys(["connect", "logout"], "pyvcell.vcml.vcml_remote"),
-    "simulate": "pyvcell.vcml.vcml_simulation",
-    "VcmlWriter": "pyvcell.vcml.vcml_writer",
-    **dict.fromkeys(["get_workspace_dir", "set_workspace_dir"], "pyvcell.vcml.workspace"),
+}
+
+# Missing optional top-level module -> the extra that provides it, for a clear hint.
+_EXTRA_FOR_MODULE: dict[str, str] = {
+    "libvcell": "native",
+    "pyvcell_fvsolver": "solver",
+    "fvsolver": "solver",
+    "vtk": "viz",
+    "pyvista": "viz",
+    "matplotlib": "viz",
+    "imageio": "viz",
+    "trame": "viz",
+    "trame_server": "viz",
+    "trame_vtk": "viz",
+    "trame_vuetify": "viz",
+    "requests": "remote",
+    "requests_oauth2client": "remote",
+    "urllib3": "remote",
+    "dateutil": "remote",
+    "overrides": "remote",
+    "tensorstore": "io",
+    "zarr": "io",
+    "h5py": "io",
+    "orjson": "io",
+    "typer": "io",
+    "antimony": "convert",
+    "libsbml": "convert",
+    "sympy": "convert",
 }
 
 
@@ -184,7 +163,17 @@ def __getattr__(name: str) -> object:
     module_path = _LAZY_IMPORTS.get(name)
     if module_path is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    value = getattr(importlib.import_module(module_path), name)
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:
+        missing = (exc.name or "").split(".")[0]
+        extra = _EXTRA_FOR_MODULE.get(missing)
+        hint = f"pip install pyvcell[{extra}]" if extra else "pip install pyvcell[all]"
+        raise ModuleNotFoundError(
+            f"pyvcell.vcml.{name} requires the optional dependency '{missing}', which is not installed. "
+            f"Install it with `{hint}`."
+        ) from exc
+    value = getattr(module, name)
     globals()[name] = value  # cache so __getattr__ is not consulted again for this name
     return value
 

--- a/pyvcell/vcml/utils.py
+++ b/pyvcell/vcml/utils.py
@@ -9,14 +9,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyvcell._internal.api.vcell_client.api_client import ApiClient
+    from pyvcell.sbml.sbml_spatial_model import SbmlSpatialModel
 from pathlib import Path
 
-import sympy  # type: ignore[import-untyped]
-from libvcell import sbml_to_vcml, vcml_to_sbml
-from sympy.parsing.sympy_parser import parse_expr  # type: ignore[import-untyped]
-
 from pyvcell._internal.simdata.simdata_models import VariableType
-from pyvcell.sbml.sbml_spatial_model import SbmlSpatialModel
 from pyvcell.vcml.models import Application, Biomodel, VCMLDocument
 from pyvcell.vcml.vcml_reader import VcmlReader
 from pyvcell.vcml.vcml_writer import VcmlWriter
@@ -45,6 +41,8 @@ def _from_sbml_object(sbml_spatial_model: SbmlSpatialModel) -> Biomodel:
     Returns:
         BioModel: The imported model as a BioModel object.
     """
+    from libvcell import sbml_to_vcml
+
     with tempfile.TemporaryDirectory() as tmp_dir_name:
         tmp_dir_path = Path(tmp_dir_name)
         tmp_dir_path.mkdir(parents=True, exist_ok=True)
@@ -73,6 +71,10 @@ def _to_sbml_object(bio_model: Biomodel, application_name: str, round_trip_valid
     Returns:
         SbmlSpatialModel: The VCell Biomodel as a SBML Spatial Model.
     """
+    from libvcell import vcml_to_sbml
+
+    from pyvcell.sbml.sbml_spatial_model import SbmlSpatialModel
+
     if application_name not in [app.name for app in bio_model.applications]:
         raise ValueError(f"Application name '{application_name}' not found in the Biomodel.")
 
@@ -105,6 +107,9 @@ def field_data_refs(bio_model: Biomodel, simulation_name: str) -> set[tuple[str,
     - field_data_type: VariableType
     - field_data_time: float
     """
+    import sympy  # type: ignore[import-untyped]
+    from sympy.parsing.sympy_parser import parse_expr  # type: ignore[import-untyped]
+
     application: Application | None = None
     for app in bio_model.applications:
         for sim in app.simulations:

--- a/pyvcell/vcml/vcml_simulation.py
+++ b/pyvcell/vcml/vcml_simulation.py
@@ -2,8 +2,6 @@ import os
 import tempfile
 from pathlib import Path
 
-from libvcell import vcml_to_finite_volume_input
-
 from pyvcell._internal.solvers.fvsolver import solve as fvsolve
 from pyvcell.sim_results.result import Result
 from pyvcell.vcml.field import Field
@@ -13,6 +11,8 @@ from pyvcell.vcml.workspace import get_workspace_dir
 
 
 def simulate(biomodel: Biomodel, simulation: Simulation | str, fields: list[Field] | None = None) -> Result:
+    from libvcell import vcml_to_finite_volume_input
+
     vcml: str = to_vcml_str(bio_model=biomodel)
     out_dir = Path(tempfile.mkdtemp(prefix="out_dir_", dir=get_workspace_dir()))
 

--- a/tests/vcml/test_lightweight_import.py
+++ b/tests/vcml/test_lightweight_import.py
@@ -1,0 +1,78 @@
+"""The data models + VCML reader must import with only the core dependencies.
+
+Downstream consumers (e.g. vcell-fenics) import ``pyvcell.vcml.models_math`` and
+``VcmlReader.biomodel_from_file`` with only pydantic + lxml + numpy + numexpr
+installed; importing them must not drag in the solver / viz / remote / libvcell
+stack.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import pyvcell.vcml as vc
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "data" / "TinySpatialProject_Application0.vcml"
+
+# Top-level modules that belong to the heavy optional extras.
+_HEAVY = {
+    "libvcell",
+    "pyvcell_fvsolver",
+    "vtk",
+    "pyvista",
+    "matplotlib",
+    "imageio",
+    "trame",
+    "requests",
+    "urllib3",
+    "tensorstore",
+    "zarr",
+    "h5py",
+    "antimony",
+    "libsbml",
+    "sympy",
+}
+
+
+def test_data_layer_import_pulls_no_heavy_deps() -> None:
+    """In a fresh interpreter, importing the data models + reader (and reading a
+    VCML file) must not import any heavy optional dependency."""
+    code = (
+        "import sys\n"
+        "from pyvcell.vcml.models_math import MathDescription\n"
+        "from pyvcell.vcml.models_geometry import Geometry\n"
+        "from pyvcell.vcml import MathDescription, VcmlReader, Geometry, Biomodel\n"
+        "bm = VcmlReader.biomodel_from_file(sys.argv[1])\n"
+        f"heavy = sorted(m for m in sys.modules if m.split('.')[0] in {sorted(_HEAVY)!r})\n"
+        "assert not heavy, 'heavy modules imported: ' + repr(heavy)\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code, str(FIXTURE)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_missing_extra_raises_helpful_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A heavy name whose optional dependency is missing reports the extra to install."""
+
+    def fake_import(name: str) -> object:
+        raise ModuleNotFoundError("No module named 'vtk'", name="vtk")
+
+    monkeypatch.setattr(vc, "importlib", types.SimpleNamespace(import_module=fake_import))
+    # Call __getattr__ directly so the lazy path runs even if the name was cached.
+    with pytest.raises(ModuleNotFoundError, match=r"pyvcell\[viz\]"):
+        vc.__getattr__("SegmentedImageGeometry")
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError):
+        vc.__getattr__("does_not_exist")

--- a/tests/vcml/test_lightweight_import.py
+++ b/tests/vcml/test_lightweight_import.py
@@ -52,7 +52,7 @@ def test_data_layer_import_pulls_no_heavy_deps() -> None:
         "assert not heavy, 'heavy modules imported: ' + repr(heavy)\n"
         "print('ok')\n"
     )
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603 - fixed args, sys.executable + literal code
         [sys.executable, "-c", code, str(FIXTURE)],
         capture_output=True,
         text=True,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -3351,17 +3351,22 @@ name = "pyvcell"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "lxml" },
+    { name = "numexpr" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+
+[package.optional-dependencies]
+all = [
     { name = "antimony" },
     { name = "h5py" },
     { name = "imageio" },
     { name = "libvcell" },
-    { name = "lxml" },
     { name = "matplotlib" },
-    { name = "numexpr" },
-    { name = "numpy" },
     { name = "orjson" },
     { name = "overrides" },
-    { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "python-libsbml" },
     { name = "pyvcell-fvsolver" },
@@ -3375,10 +3380,44 @@ dependencies = [
     { name = "trame-vtk" },
     { name = "trame-vuetify" },
     { name = "typer" },
-    { name = "typing-extensions" },
     { name = "urllib3" },
     { name = "vtk" },
     { name = "zarr" },
+]
+convert = [
+    { name = "antimony" },
+    { name = "python-libsbml" },
+    { name = "sympy" },
+]
+io = [
+    { name = "h5py" },
+    { name = "orjson" },
+    { name = "tensorstore" },
+    { name = "typer" },
+    { name = "zarr" },
+]
+native = [
+    { name = "libvcell" },
+]
+remote = [
+    { name = "overrides" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "requests-oauth2client" },
+    { name = "urllib3" },
+]
+solver = [
+    { name = "pyvcell-fvsolver" },
+]
+viz = [
+    { name = "imageio" },
+    { name = "matplotlib" },
+    { name = "pyvista" },
+    { name = "trame" },
+    { name = "trame-server" },
+    { name = "trame-vtk" },
+    { name = "trame-vuetify" },
+    { name = "vtk" },
 ]
 
 [package.dev-dependencies]
@@ -3392,6 +3431,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyvcell", extra = ["all"] },
     { name = "tox" },
     { name = "trame-jupyter-extension" },
     { name = "types-requests" },
@@ -3406,35 +3446,37 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "antimony", specifier = ">=3.1.3" },
-    { name = "h5py", specifier = ">=3.11.0,<4" },
-    { name = "imageio", specifier = ">=2.37.0,<3" },
-    { name = "libvcell", specifier = ">=0.0.15.2" },
+    { name = "antimony", marker = "extra == 'convert'", specifier = ">=3.1.3" },
+    { name = "h5py", marker = "extra == 'io'", specifier = ">=3.11.0,<4" },
+    { name = "imageio", marker = "extra == 'viz'", specifier = ">=2.37.0,<3" },
+    { name = "libvcell", marker = "extra == 'native'", specifier = ">=0.0.15.2" },
     { name = "lxml", specifier = ">=6.1.0,<7" },
-    { name = "matplotlib", specifier = ">=3.10.0,<4" },
+    { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.10.0,<4" },
     { name = "numexpr", specifier = ">=2.10,<3" },
     { name = "numpy", specifier = ">=1.26.4,<3.0" },
-    { name = "orjson", specifier = ">=3.10.3,<4" },
-    { name = "overrides", specifier = ">=7.7.0,<8" },
+    { name = "orjson", marker = "extra == 'io'", specifier = ">=3.10.3,<4" },
+    { name = "overrides", marker = "extra == 'remote'", specifier = ">=7.7.0,<8" },
     { name = "pydantic", specifier = ">=2.10.5,<3" },
-    { name = "python-dateutil", specifier = ">=2.8.2,<3" },
-    { name = "python-libsbml", specifier = ">=5.20.4,<6" },
-    { name = "pyvcell-fvsolver", specifier = ">=0.2.1" },
-    { name = "pyvista", specifier = ">=0.44.2,<1" },
-    { name = "requests", specifier = ">=2.32.3,<3" },
-    { name = "requests-oauth2client", specifier = ">=1.6.0,<2" },
-    { name = "sympy", specifier = ">=1.13.1,<2" },
-    { name = "tensorstore", specifier = ">=0.1.72,<1" },
-    { name = "trame", specifier = ">=3.8.1,<4" },
-    { name = "trame-server", specifier = ">=3.4.0,<4" },
-    { name = "trame-vtk", specifier = ">=2.8.15,<3" },
-    { name = "trame-vuetify", specifier = ">=3.2.2,<4" },
-    { name = "typer", specifier = ">=0.12.3,<1.0.0" },
+    { name = "python-dateutil", marker = "extra == 'remote'", specifier = ">=2.8.2,<3" },
+    { name = "python-libsbml", marker = "extra == 'convert'", specifier = ">=5.20.4,<6" },
+    { name = "pyvcell", extras = ["solver", "viz", "remote", "io", "convert", "native"], marker = "extra == 'all'" },
+    { name = "pyvcell-fvsolver", marker = "extra == 'solver'", specifier = ">=0.2.1" },
+    { name = "pyvista", marker = "extra == 'viz'", specifier = ">=0.44.2,<1" },
+    { name = "requests", marker = "extra == 'remote'", specifier = ">=2.32.3,<3" },
+    { name = "requests-oauth2client", marker = "extra == 'remote'", specifier = ">=1.6.0,<2" },
+    { name = "sympy", marker = "extra == 'convert'", specifier = ">=1.13.1,<2" },
+    { name = "tensorstore", marker = "extra == 'io'", specifier = ">=0.1.72,<1" },
+    { name = "trame", marker = "extra == 'viz'", specifier = ">=3.8.1,<4" },
+    { name = "trame-server", marker = "extra == 'viz'", specifier = ">=3.4.0,<4" },
+    { name = "trame-vtk", marker = "extra == 'viz'", specifier = ">=2.8.15,<3" },
+    { name = "trame-vuetify", marker = "extra == 'viz'", specifier = ">=3.2.2,<4" },
+    { name = "typer", marker = "extra == 'io'", specifier = ">=0.12.3,<1.0.0" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5" },
-    { name = "urllib3", specifier = ">=2.3.0,<3" },
-    { name = "vtk", specifier = ">=9.3.1,<10" },
-    { name = "zarr", specifier = ">=2.17.2,<3" },
+    { name = "urllib3", marker = "extra == 'remote'", specifier = ">=2.3.0,<3" },
+    { name = "vtk", marker = "extra == 'viz'", specifier = ">=9.3.1,<10" },
+    { name = "zarr", marker = "extra == 'io'", specifier = ">=2.17.2,<3" },
 ]
+provides-extras = ["solver", "viz", "remote", "io", "convert", "native", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3447,6 +3489,7 @@ dev = [
     { name = "pre-commit", specifier = ">=3.8.0,<4" },
     { name = "pytest", specifier = ">=7.2.0,<8" },
     { name = "pytest-cov", specifier = ">=4.0.0,<5" },
+    { name = "pyvcell", extras = ["all"] },
     { name = "tox", specifier = ">=4.11.1,<5" },
     { name = "trame-jupyter-extension", specifier = ">=2.1.4,<3" },
     { name = "types-requests", specifier = ">=2.32.0.20241016,<3" },


### PR DESCRIPTION
## Goal

Make pyvcell's **data models + VCML read/write** usable as a lightweight, dependency-light layer, so downstream consumers (e.g. vcell-fenics) can `import pyvcell.vcml.models_math` / `import pyvcell.vcml.models_geometry` and read VCML with only **pydantic + lxml + numpy + numexpr** installed — without dragging in the solver / viz / remote / libvcell stack. `pip install pyvcell[all]` reproduces today's behavior.

## Change A — import light

- **`pyvcell/vcml/__init__.py`** rewritten (PEP 562): the light data layer is **eager** (`models`, `models_geometry`, `models_math`, `VcmlReader`); heavy names (`VcmlWriter`, `Field`, `SegmentedImageGeometry`, `VCellSession`/`connect`/`logout`/`simulate`, and the `utils`/`workspace` helpers) are imported **lazily** on first access. A `TYPE_CHECKING` block keeps static types/IDE autocomplete intact. When a heavy name's optional dependency is missing, the lazy import raises a clear error, e.g. `pyvcell.vcml.simulate requires the optional dependency 'pyvcell_fvsolver' … Install it with pip install pyvcell[solver]`.
- **Decouple `libvcell` from the data/reader path**: every `import libvcell` (`_internal/simdata/python_infix.py`, `vcml/utils.py`, `vcml/vcml_simulation.py`, `sbml/sbml_simulation.py`) now lives inside the function that uses it. `utils.py`'s module-level `sympy` and `sbml_spatial_model` imports are likewise made lazy, so the light `load_vcml_*` helpers and `field`/`utils` import with core deps only.

## Change B — optional-dependency extras

Core `[project.dependencies]` is now just `lxml`, `numexpr`, `numpy`, `pydantic`, `typing-extensions`. Everything else moved to `[project.optional-dependencies]`:

| extra | packages |
|---|---|
| `solver` | pyvcell-fvsolver |
| `viz` | vtk, pyvista, matplotlib, imageio, trame, trame-server, trame-vtk, trame-vuetify |
| `remote` | requests, requests-oauth2client, urllib3, python-dateutil, overrides |
| `io` | tensorstore, zarr, h5py, orjson, typer |
| `convert` | antimony, python-libsbml, sympy |
| `native` | libvcell |
| `all` | union of all the above |

`pyvcell[all]` is added to the `dev` dependency-group so `uv sync`/`uv run` (which include `dev` by default) keep the full feature set for dev/CI — no Makefile/CI command changes needed. (uv has no `default-extras` field; the dev-group self-reference is the version-portable idiom.) A `[tool.deptry] DEP002` ignore covers that self-reference.

## Change C — reader robustness

Already landed in #44 (merged): the physiology visitors are lenient, so the bundled corpus loads 100% (was 77%). This branch includes that plus a spot-check (50/50) and the existing `test_reader_leniency.py`.

## Verification (clean venv, core deps only)

```
$ uv pip install .            # core only
  installs: lxml, numexpr, numpy, pydantic(+core), typing-extensions/inspection  — and nothing else
$ python -c "from pyvcell.vcml.models_math import MathDescription; \
             from pyvcell.vcml.models_geometry import Geometry; \
             from pyvcell.vcml import VcmlReader; \
             bm = VcmlReader.biomodel_from_file('some.vcml'); import sys; \
             assert 'libvcell' not in sys.modules and 'vtk' not in sys.modules"
  -> reads VCML, math_description populated; no libvcell/vtk imported
$ python -c "import pyvcell.vcml as vc; vc.simulate"
  -> ModuleNotFoundError: … Install it with `pip install pyvcell[solver]`
```

- New `tests/vcml/test_lightweight_import.py`: subprocess-isolated assertion that the data layer + reader pull no heavy modules, plus the helpful-error behavior.
- `make check` green (ruff, mypy 310 files, deptry); `pytest tests/vcml tests/sbml` → 44 passed, 5 skipped.
- Public API unchanged; `pip install pyvcell[all]` == today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)