### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvcell"
-version = "0.2.0"
+version = "0.3.0"
 requires-python = ">=3.12,<4.0"
 description = "This is the python wrapper for vcell modeling and simulation"
 repository = "https://github.com/virtualcell/pyvcell"

--- a/uv.lock
+++ b/uv.lock
@@ -3370,7 +3370,7 @@ wheels = [
 
 [[package]]
 name = "pyvcell"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },


### PR DESCRIPTION
Version bump to **0.3.0** ahead of the release.

Since 0.2.0 the project gained (PRs #41–#48):
- `MathDescription` data model exposed in the VCML reader/writer (per-application generated math)
- Advection **velocity** on species mappings; `add_model_parameter` role defaults to `"user defined"` (matches VCell Java)
- **Lightweight data layer**: slim core install + optional-dependency extras (`pip install pyvcell[all]` for the full stack), lazy (PEP 562) imports
- **Lenient VCML reader**: best-effort physiology parse (real-biomodel corpus load 77% → 100%)
- Volume-variable shape robustness in the zarr writer; `libvcell>=0.0.15.3`
- Maintenance: dropped Python 3.9/3.10/3.11 from CI (requires-python `>=3.12`), removed poetry

The release workflow sets the published version from the release tag, but this keeps the in-repo `pyproject.toml` / `uv.lock` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)