### PR TITLE
Add py.typed marker (+ type-checking docs); bump 0.3.1

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.11 or later
+- Python 3.12 or later
 
 ## Install from PyPI
 
@@ -33,6 +33,30 @@ import pyvcell.vcml as vc
 print("pyvcell imported successfully")
 ```
 
+## Type checking
+
+pyvcell ships a `py.typed` marker ([PEP 561](https://peps.python.org/pep-0561/)),
+so type checkers (mypy, pyright) use its inline annotations when you import it —
+e.g. `pyvcell.vcml.models_math.MathDescription` is fully typed.
+
+If you type-check a project against pyvcell but **don't install all of its
+optional extras**, your checker may follow into pyvcell's optional-dependency
+modules and report `import-not-found` for deps you didn't install (`libvcell`,
+`sympy`, …). Those aren't your bugs — they're code paths you don't use. Tell your
+checker to use pyvcell's public types without checking its internals:
+
+```toml
+# pyproject.toml of the consuming project
+[[tool.mypy.overrides]]
+module = ["pyvcell.*"]
+follow_imports = "silent"
+```
+
+`follow_imports = "silent"` keeps pyvcell's types flowing into your code (so your
+own usage is still fully checked) while silencing diagnostics inside pyvcell's
+optional-dependency modules. Alternatively, install the extras you use (or
+`pyvcell[all]`) so those imports resolve.
+
 ## Workspace directory
 
 pyvcell stores simulation output in a **workspace directory**. By default this is `./workspace` relative to your current working directory. You can change it:
@@ -49,9 +73,9 @@ vc.set_workspace_dir("/path/to/my/workspace")
 
 The workspace directory is created automatically if it doesn't exist.
 
-## Included visualization libraries
+## Visualization libraries
 
-pyvcell bundles several visualization libraries, all installed automatically:
+The visualization stack lives in the `viz` extra (`pip install "pyvcell[viz]"`, or `pyvcell[all]`):
 
 - **Matplotlib** — 2D plots and concentration time series
 - **VTK / PyVista** — 3D volume rendering and mesh visualization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvcell"
-version = "0.3.0"
+version = "0.3.1"
 requires-python = ">=3.12,<4.0"
 description = "This is the python wrapper for vcell modeling and simulation"
 repository = "https://github.com/virtualcell/pyvcell"

--- a/uv.lock
+++ b/uv.lock
@@ -3370,7 +3370,7 @@ wheels = [
 
 [[package]]
 name = "pyvcell"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },


### PR DESCRIPTION
## What

- **`pyvcell/py.typed`** — PEP 561 marker so third parties' type checkers (mypy, pyright) use pyvcell's inline annotations. Verified it's included in the built wheel.
- **Docs: a "Type checking" section** in `installation.md` explaining the marker and the recommended consumer-side mypy override for projects that don't install every optional extra:
  ```toml
  [[tool.mypy.overrides]]
  module = ["pyvcell.*"]
  follow_imports = "silent"
  ```
- Version bump to **0.3.1**; fixed two stale install-doc lines (Python ≥3.12; the viz stack is the `viz` extra, not auto-installed).

## Why the docs note (and why not inline `# type: ignore`)

`py.typed` makes pyvcell's types visible to consumers (verified: a consumer's `MathDescription.name` → `int` assignment is now caught). But a consumer that doesn't install all extras would, by default (`follow_imports = normal`), have mypy follow into pyvcell's optional-dependency modules and report `import-not-found` for deps it didn't install.

We deliberately did **not** suppress those with inline `# type: ignore` on the optional imports, because:
- it would **weaken pyvcell's own strictness** (the dep would have to be untyped everywhere, which also cascades into `no-any-return` fixes), and
- it doesn't even lint clean — the error code is environment-dependent (`import-untyped` with the dep installed vs `import-not-found` without), so under `warn_unused_ignores` the two-code form is flagged `Unused "type: ignore[import-not-found]"`, and ruff `PGH003` blocks the bare form.

`follow_imports = "silent"` is consumer-side config (it never ships in the wheel and has zero effect on pyvcell's own CI). It keeps pyvcell's types flowing into the consumer's code — so their own usage is fully checked — while silencing only pyvcell's internal optional-dependency diagnostics.

## Verification

- `make check` green — ruff, ruff-format, mypy (312 files, **unchanged** — no internal weakening), deptry, lock.
- `mkdocs build -s` green.
- Built wheel contains `pyvcell/py.typed`.
- A wheel-installed (non-editable) consumer: types are used (real type errors caught); with the documented override, pyvcell's internal optional-dep noise is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)