### PR TITLE
Add cartesian_mesh_from_geometry convenience function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyvcell"
-version = "0.3.1"
+version = "0.3.2"
 requires-python = ">=3.12,<4.0"
 description = "This is the python wrapper for vcell modeling and simulation"
 repository = "https://github.com/virtualcell/pyvcell"

--- a/pyvcell/vcml/__init__.py
+++ b/pyvcell/vcml/__init__.py
@@ -91,7 +91,7 @@ if TYPE_CHECKING:
         write_vcml_file,
     )
     from pyvcell.vcml.vcml_remote import connect, logout
-    from pyvcell.vcml.vcml_simulation import simulate
+    from pyvcell.vcml.vcml_simulation import cartesian_mesh_from_geometry, simulate
     from pyvcell.vcml.vcml_writer import VcmlWriter
     from pyvcell.vcml.workspace import get_workspace_dir, set_workspace_dir
 
@@ -103,7 +103,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "VcmlWriter": "pyvcell.vcml.vcml_writer",
     **dict.fromkeys(["SimulationJob", "VCellSession"], "pyvcell.vcml.session"),
     **dict.fromkeys(["connect", "logout"], "pyvcell.vcml.vcml_remote"),
-    "simulate": "pyvcell.vcml.vcml_simulation",
+    **dict.fromkeys(["simulate", "cartesian_mesh_from_geometry"], "pyvcell.vcml.vcml_simulation"),
     **dict.fromkeys(["get_workspace_dir", "set_workspace_dir"], "pyvcell.vcml.workspace"),
     **dict.fromkeys(
         [
@@ -230,6 +230,7 @@ __all__ = [
     "VcmlWriter",
     "Velocity",
     "Version",
+    "cartesian_mesh_from_geometry",
     "connect",
     "field_data_refs",
     "get_workspace_dir",

--- a/pyvcell/vcml/models_geometry.py
+++ b/pyvcell/vcml/models_geometry.py
@@ -9,6 +9,7 @@ packages depend on it without pulling in biomodel constructs.
 """
 
 import zlib
+from typing import TYPE_CHECKING
 
 import numpy as np
 from pydantic import Field
@@ -19,6 +20,9 @@ from pyvcell._internal.geometry.segmented_image_geometry import (
 )
 from pyvcell.sim_results.var_types import NDArray3Du8
 from pyvcell.vcml.models_base import StrEnum, VcmlNode
+
+if TYPE_CHECKING:
+    from pyvcell._internal.simdata.mesh import CartesianMesh
 
 
 class PixelClass(VcmlNode):
@@ -201,3 +205,13 @@ class Geometry(VcmlNode):
     @property
     def surface_class_names(self) -> list[str]:
         return [surface_class.name for surface_class in self.surface_classes]
+
+    def to_cartesian_mesh(self, mesh_size: tuple[int, int, int] | None = None, resolution: int = 50) -> "CartesianMesh":
+        """Generate the VCell finite-volume :class:`CartesianMesh` for this geometry.
+
+        Convenience wrapper around :func:`pyvcell.vcml.cartesian_mesh_from_geometry`;
+        requires the ``native`` and ``solver`` extras (libvcell + pyvcell-fvsolver).
+        """
+        from pyvcell.vcml.vcml_simulation import cartesian_mesh_from_geometry
+
+        return cartesian_mesh_from_geometry(self, mesh_size=mesh_size, resolution=resolution)

--- a/pyvcell/vcml/vcml_simulation.py
+++ b/pyvcell/vcml/vcml_simulation.py
@@ -1,13 +1,18 @@
 import os
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pyvcell._internal.solvers.fvsolver import solve as fvsolve
 from pyvcell.sim_results.result import Result
 from pyvcell.vcml.field import Field
-from pyvcell.vcml.models import Biomodel, Simulation
+from pyvcell.vcml.models import Biomodel, Model, Simulation
+from pyvcell.vcml.models_geometry import Geometry
 from pyvcell.vcml.utils import to_vcml_str
 from pyvcell.vcml.workspace import get_workspace_dir
+
+if TYPE_CHECKING:
+    from pyvcell._internal.simdata.mesh import CartesianMesh
 
 
 def simulate(biomodel: Biomodel, simulation: Simulation | str, fields: list[Field] | None = None) -> Result:
@@ -46,3 +51,66 @@ def simulate(biomodel: Biomodel, simulation: Simulation | str, fields: list[Fiel
 
     # return the result
     return Result(solver_output_dir=out_dir, sim_id=sim_id, job_id=job_id)
+
+
+def cartesian_mesh_from_geometry(
+    geometry: Geometry, mesh_size: tuple[int, int, int] | None = None, resolution: int = 50
+) -> "CartesianMesh":
+    """Generate the VCell finite-volume :class:`CartesianMesh` for a geometry.
+
+    Wraps ``geometry`` in a minimal spatial biomodel (one structure per subvolume
+    and surface, plus a single diffusing probe species), runs libvcell + the FV
+    solver for one trivial time step to produce the ``.mesh`` file, parses it, and
+    returns the mesh. Requires the ``native`` and ``solver`` extras.
+
+    Args:
+        geometry: a spatial geometry (analytic or image based, dimension 1-3).
+        mesh_size: explicit ``(nx, ny, nz)`` element counts. Defaults to the image
+            size for image-based geometries, otherwise ``resolution`` along each
+            active dimension (1 on the inactive axes).
+        resolution: per-axis element count used when ``mesh_size`` is not given and
+            the geometry is not image based.
+    """
+    from pyvcell._internal.simdata.mesh import CartesianMesh
+
+    if geometry.dim < 1:
+        raise ValueError("a CartesianMesh requires a spatial geometry (dimension >= 1)")
+    if not geometry.subvolumes:
+        raise ValueError("geometry has no subvolumes to discretize")
+
+    if mesh_size is None:
+        if geometry.image is not None:
+            mesh_size = geometry.image.size
+        elif geometry.dim == 1:
+            mesh_size = (resolution, 1, 1)
+        elif geometry.dim == 2:
+            mesh_size = (resolution, resolution, 1)
+        else:
+            mesh_size = (resolution, resolution, resolution)
+
+    # Minimal spatial biomodel: a structure per geometry class and one diffusing
+    # probe species so the simulation is a valid (spatial) PDE problem.
+    model = Model(name="mesh_geometry")
+    for subvolume in geometry.subvolumes:
+        model.add_compartment(name=subvolume.name, dim=3)
+    for surface_class in geometry.surface_classes:
+        model.add_compartment(name=surface_class.name, dim=2)
+    probe = model.add_species("probe", geometry.subvolumes[0].name)
+
+    biomodel = Biomodel(name="mesh_geometry", model=model)
+    application = biomodel.add_application("mesh_geometry", geometry=geometry)
+    for subvolume in geometry.subvolumes:
+        application.map_compartment(subvolume.name, subvolume.name)
+    for surface_class in geometry.surface_classes:
+        application.map_compartment(surface_class.name, surface_class.name)
+    application.map_species(probe, init_conc=0.0, diff_coef=1.0)
+    application.add_sim(name="mesh", duration=1e-8, output_time_step=1e-8, mesh_size=mesh_size)
+
+    result = simulate(biomodel, "mesh")
+    try:
+        mesh_file = result.solver_output_dir / f"SimID_{result.sim_id}_{result.job_id}_.mesh"
+        mesh = CartesianMesh(mesh_file=mesh_file)
+        mesh.read()
+    finally:
+        result.cleanup()
+    return mesh

--- a/tests/vcml/test_mesh_from_geometry.py
+++ b/tests/vcml/test_mesh_from_geometry.py
@@ -1,0 +1,46 @@
+"""Generate a CartesianMesh directly from a Geometry (no full model needed)."""
+
+import pyvcell.vcml as vc
+from pyvcell._internal.simdata.mesh import CartesianMesh
+
+
+def _two_region_geometry(dim: int, extent: tuple[float, float, float]) -> vc.Geometry:
+    """A sphere/circle subdomain inside a background, with a separating membrane.
+
+    The region-defining subvolume is added before the background so it wins
+    (earlier subvolumes have higher priority).
+    """
+    geo = vc.Geometry(name="g", dim=dim, extent=extent, origin=(0.0, 0.0, 0.0))
+    center = (extent[0] / 2, extent[1] / 2, extent[2] / 2 if dim == 3 else 0.0)
+    geo.add_sphere("cell", radius=2.0, center=center)
+    geo.add_background("bg")
+    geo.add_surface("cell_bg_membrane", "cell", "bg")
+    return geo
+
+
+def test_cartesian_mesh_from_geometry_3d() -> None:
+    geo = _two_region_geometry(3, (8.0, 8.0, 8.0))
+    mesh = vc.cartesian_mesh_from_geometry(geo, mesh_size=(12, 12, 12))
+
+    assert isinstance(mesh, CartesianMesh)
+    assert mesh.size == [12, 12, 12]
+    assert mesh.extent == [8.0, 8.0, 8.0]
+    assert mesh.origin == [0.0, 0.0, 0.0]
+    assert mesh.dimension == 3
+    assert {region[3] for region in mesh.volume_regions} == {"bg", "cell"}
+    assert len(mesh.membrane_regions) >= 1
+
+
+def test_geometry_to_cartesian_mesh_2d() -> None:
+    geo = _two_region_geometry(2, (8.0, 8.0, 1.0))
+    mesh = geo.to_cartesian_mesh(mesh_size=(16, 16, 1))
+
+    assert mesh.size == [16, 16, 1]
+    assert mesh.dimension == 2
+    assert {region[3] for region in mesh.volume_regions} == {"bg", "cell"}
+
+
+def test_default_mesh_size_uses_resolution() -> None:
+    geo = _two_region_geometry(3, (8.0, 8.0, 8.0))
+    mesh = geo.to_cartesian_mesh(resolution=10)
+    assert mesh.size == [10, 10, 10]

--- a/uv.lock
+++ b/uv.lock
@@ -3370,7 +3370,7 @@ wheels = [
 
 [[package]]
 name = "pyvcell"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },


### PR DESCRIPTION
## What

Generate a VCell finite-volume `CartesianMesh` directly from a `Geometry`, without hand-assembling a biomodel:

```python
import pyvcell.vcml as vc

geo = vc.Geometry(name="g", dim=3, extent=(8, 8, 8), origin=(0, 0, 0))
geo.add_sphere("cell", radius=2.0, center=(4, 4, 4))
geo.add_background("bg")
geo.add_surface("cell_bg_membrane", "cell", "bg")

mesh = vc.cartesian_mesh_from_geometry(geo, mesh_size=(64, 64, 64))
# or the convenience method:
mesh = geo.to_cartesian_mesh()       # mesh_size defaults to resolution=50 per active axis
```

## How

`cartesian_mesh_from_geometry` (in `vcml_simulation.py`) wraps the geometry in a **minimal spatial biomodel** — one structure per subvolume (Feature) and surface (Membrane), plus a single diffusing "probe" species so the simulation is a valid PDE — then:
1. uses libvcell (`vcml_to_finite_volume_input`) + the FV solver (`simulate`) to run one trivial time step, which writes the `.mesh` file (the `.mesh` is produced by the solver from the `.vcg`, not by the input step);
2. parses it with `CartesianMesh(...).read()`;
3. cleans up the temp output dir and returns the mesh.

`mesh_size` defaults to the **image size** for image-based geometries, otherwise `resolution` (default 50) along each active dimension. Note: the region-defining subvolume must be added before the background (`add_sphere` then `add_background`), since earlier subvolumes have higher priority.

## API placement / import-weight

- Implementation lives in the heavy/solver module and is **exposed lazily** from `pyvcell.vcml` (like `simulate`).
- `Geometry.to_cartesian_mesh(...)` delegates via a **lazy import**, so `import pyvcell.vcml.models_geometry` stays import-light (verified: pulls no `libvcell`/`pyvcell_fvsolver`/`vtk`/`zarr`).
- Requires the `native` + `solver` extras at call time.

## Tests / verification

- `tests/vcml/test_mesh_from_geometry.py`: 2D and 3D analytic geometries (both the standalone function and the `Geometry` method), plus the default-resolution path — asserts size/extent/origin, dimension, the two volume regions (`bg`, `cell`), and the membrane region. (1D skipped per request; focus on 2D/3D.)
- Manually verified against fixtures too (1D/3D analytic, image-based Bunny → size `[107, 87, 107]`).
- `make check` green (ruff, mypy 313 files, deptry); `pytest tests/vcml` → 46 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)