### PR TITLE
Add Zenodo release archiving (concept zenodo.21127437)

### DIFF
--- a/.github/workflows/zenodo-archive.yml
+++ b/.github/workflows/zenodo-archive.yml
@@ -1,0 +1,13 @@
+name: Archive release to Zenodo
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  archive:
+    uses: virtualcell/zenodo-maint/.github/workflows/archive.reusable.yml@v1
+    with:
+      tag: ${{ github.event.release.tag_name }}
+    secrets:
+      ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}

--- a/.github/workflows/zenodo-drift.yml
+++ b/.github/workflows/zenodo-drift.yml
@@ -1,0 +1,10 @@
+name: Zenodo drift check
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch: {}
+
+jobs:
+  drift:
+    uses: virtualcell/zenodo-maint/.github/workflows/drift.reusable.yml@v1

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,28 @@
+{
+  "upload_type": "software",
+  "title": "pyvcell",
+  "license": "mit",
+  "creators": [
+    {
+      "name": "Schaff, James C.",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0000-0003-3286-7736"
+    },
+    {
+      "name": "Patrie, Alexander",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0009-0002-6886-2291"
+    },
+    {
+      "name": "Drescher, Logan",
+      "affiliation": "University of Connecticut School of Medicine"
+    },
+    {
+      "name": "Moraru, Ion I.",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0000-0002-3746-9676"
+    }
+  ],
+  "description": "<p>pyvcell is the Python wrapper for Virtual Cell (VCell) modeling and simulation — local scripting of spatial modeling, simulation, data analysis, and visualization, plus access to the Virtual Cell remote APIs. Supports VCML and SBML import/export.</p>",
+  "related_identifiers": []
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "pyvcell"
+type: software
+repository-code: "https://github.com/virtualcell/pyvcell"
+license: MIT
+doi: 10.5281/zenodo.21127437   # concept DOI (all versions)
+authors:
+  - family-names: "Schaff"
+    given-names: "James C."
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0000-0003-3286-7736"
+  - family-names: "Patrie"
+    given-names: "Alexander"
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0009-0002-6886-2291"
+  - family-names: "Drescher"
+    given-names: "Logan"
+    affiliation: "University of Connecticut School of Medicine"
+  - family-names: "Moraru"
+    given-names: "Ion I."
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0000-0002-3746-9676"


### PR DESCRIPTION
Wires release archiving to Zenodo concept **10.5281/zenodo.21127437** via the `virtualcell/zenodo-maint` reusable workflow, with a corrected author list (Ion Moraru as final author).

- **CITATION.cff** — citation + concept DOI
- **.zenodo.json** — deposit metadata
- **zenodo-archive.yml** — on `release: published`
- **zenodo-drift.yml** — weekly drift check

`ZENODO_TOKEN` secret already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)