### PR TITLE
Fix title casing: pyvcell → pyVCell

### DIFF
--- a/.github/workflows/zenodo-drift.yml
+++ b/.github/workflows/zenodo-drift.yml
@@ -2,7 +2,7 @@ name: Zenodo drift check
 
 on:
   schedule:
-    - cron: '0 12 * * 1'
+    - cron: "0 12 * * 1"
   workflow_dispatch: {}
 
 jobs:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,28 +1,28 @@
 {
-  "upload_type": "software",
-  "title": "pyVCell",
-  "license": "mit",
-  "creators": [
-    {
-      "name": "Schaff, James C.",
-      "affiliation": "University of Connecticut School of Medicine",
-      "orcid": "0000-0003-3286-7736"
-    },
-    {
-      "name": "Patrie, Alexander",
-      "affiliation": "University of Connecticut School of Medicine",
-      "orcid": "0009-0002-6886-2291"
-    },
-    {
-      "name": "Drescher, Logan",
-      "affiliation": "University of Connecticut School of Medicine"
-    },
-    {
-      "name": "Moraru, Ion I.",
-      "affiliation": "University of Connecticut School of Medicine",
-      "orcid": "0000-0002-3746-9676"
-    }
-  ],
-  "description": "<p>pyvcell is the Python wrapper for Virtual Cell (VCell) modeling and simulation — local scripting of spatial modeling, simulation, data analysis, and visualization, plus access to the Virtual Cell remote APIs. Supports VCML and SBML import/export.</p>",
-  "related_identifiers": []
+    "upload_type": "software",
+    "title": "pyVCell",
+    "license": "mit",
+    "creators": [
+        {
+            "name": "Schaff, James C.",
+            "affiliation": "University of Connecticut School of Medicine",
+            "orcid": "0000-0003-3286-7736"
+        },
+        {
+            "name": "Patrie, Alexander",
+            "affiliation": "University of Connecticut School of Medicine",
+            "orcid": "0009-0002-6886-2291"
+        },
+        {
+            "name": "Drescher, Logan",
+            "affiliation": "University of Connecticut School of Medicine"
+        },
+        {
+            "name": "Moraru, Ion I.",
+            "affiliation": "University of Connecticut School of Medicine",
+            "orcid": "0000-0002-3746-9676"
+        }
+    ],
+    "description": "<p>pyvcell is the Python wrapper for Virtual Cell (VCell) modeling and simulation — local scripting of spatial modeling, simulation, data analysis, and visualization, plus access to the Virtual Cell remote APIs. Supports VCML and SBML import/export.</p>",
+    "related_identifiers": []
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "upload_type": "software",
-  "title": "pyvcell",
+  "title": "pyVCell",
   "license": "mit",
   "creators": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "pyVCell"
 type: software
 repository-code: "https://github.com/virtualcell/pyvcell"
 license: MIT
-doi: 10.5281/zenodo.21127437   # concept DOI (all versions)
+doi: 10.5281/zenodo.21127437 # concept DOI (all versions)
 authors:
   - family-names: "Schaff"
     given-names: "James C."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using these metadata."
-title: "pyvcell"
+title: "pyVCell"
 type: software
 repository-code: "https://github.com/virtualcell/pyvcell"
 license: MIT


### PR DESCRIPTION
Aligns the `.zenodo.json` and `CITATION.cff` titles with the published Zenodo record, which displays **pyVCell** — both files had the lowercased `pyvcell`.

Because release archiving uses `.zenodo.json` verbatim, the next release would have **regressed** the published title to `pyvcell`. Updating both files keeps them consistent and prevents a `cffconvert` regen from reintroducing the lowercase form.

Surfaced by `zenodo-maint audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZx7w9BexQc9wWU5JoHYaF