### PR TITLE
chore: correct LICENSE copyright holder to UConn Health

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024, Jim Schaff
+Copyright (c) 2024 The University of Connecticut Health Center (UConn Health)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What
Corrects the MIT `LICENSE` copyright holder from an individual (**Jim Schaff**)
to the institution — **The University of Connecticut Health Center (UConn
Health)**.

Only the copyright line changes:
```diff
-Copyright (c) 2024, Jim Schaff
+Copyright (c) 2024 The University of Connecticut Health Center (UConn Health)
```

The license itself is unchanged (still MIT). This matches the holder used for the
sibling `vcell-solvers` onboarding.
